### PR TITLE
Add a method to access the srWindow attribute of ScreenBufferInfo

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -7,7 +7,7 @@ use winapi::um::wincon::{
     self, GetConsoleScreenBufferInfo, SetConsoleTextAttribute,
     CONSOLE_SCREEN_BUFFER_INFO, FOREGROUND_BLUE as FG_BLUE,
     FOREGROUND_GREEN as FG_GREEN, FOREGROUND_INTENSITY as FG_INTENSITY,
-    FOREGROUND_RED as FG_RED,
+    FOREGROUND_RED as FG_RED, SMALL_RECT,
 };
 
 use crate::{AsHandleRef, HandleRef};
@@ -125,6 +125,14 @@ impl ScreenBufferInfo {
     /// size.
     pub fn max_window_size(&self) -> (i16, i16) {
         (self.0.dwMaximumWindowSize.X, self.0.dwMaximumWindowSize.Y)
+    }
+
+    /// Returns the console screen buffer coordinates of the upper-left and
+    /// lower-right corners of the display window.
+    ///
+    /// This corresponds to `srWindow`.
+    pub fn window_rect(&self) -> SMALL_RECT {
+        self.0.srWindow
     }
 }
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -7,7 +7,7 @@ use winapi::um::wincon::{
     self, GetConsoleScreenBufferInfo, SetConsoleTextAttribute,
     CONSOLE_SCREEN_BUFFER_INFO, FOREGROUND_BLUE as FG_BLUE,
     FOREGROUND_GREEN as FG_GREEN, FOREGROUND_INTENSITY as FG_INTENSITY,
-    FOREGROUND_RED as FG_RED, SMALL_RECT,
+    FOREGROUND_RED as FG_RED,
 };
 
 use crate::{AsHandleRef, HandleRef};
@@ -131,9 +131,26 @@ impl ScreenBufferInfo {
     /// lower-right corners of the display window.
     ///
     /// This corresponds to `srWindow`.
-    pub fn window_rect(&self) -> SMALL_RECT {
-        self.0.srWindow
+    pub fn window_rect(&self) -> SmallRect {
+        SmallRect {
+            left: self.0.srWindow.Left,
+            top: self.0.srWindow.Top,
+            right: self.0.srWindow.Right,
+            bottom: self.0.srWindow.Bottom,
+        }
     }
+}
+
+/// Defines the coordinates of the upper left and lower right corners of a rectangle.
+///
+/// This corresponds to [`SMALL_RECT`].
+///
+/// [`SMALL_RECT`]: https://docs.microsoft.com/en-us/windows/console/small-rect-str
+pub struct SmallRect {
+    pub left: i16,
+    pub top: i16,
+    pub right: i16,
+    pub bottom: i16,
 }
 
 /// A Windows console.


### PR DESCRIPTION
Hello,

This PR adds a method to `ScreenBufferInfo` to expose the `srWindow` attribute of the underlying `CONSOLE_SCREEN_BUFFER_INFO`.