### PR TITLE
Go to non-empty documentation by default on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ features = [
   "winerror",
   "winnt",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-pc-windows-msvc"]


### PR DESCRIPTION
Currently https://docs.rs/winapi-util goes to the x86_64-unknown-linux-gnu build of this crate by default, which is empty. After this change, the same link will show useful documentation.