### PR TITLE
Change the return type of `volume_serial_number` to `u32`.

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -99,8 +99,8 @@ impl Information {
     /// Return the serial number of the volume that the file is on.
     ///
     /// This corresponds to `dwVolumeSerialNumber`.
-    pub fn volume_serial_number(&self) -> u64 {
-        self.0.dwVolumeSerialNumber as u64
+    pub fn volume_serial_number(&self) -> u32 {
+        self.0.dwVolumeSerialNumber
     }
 
     /// Return the file size, in bytes.
@@ -113,8 +113,8 @@ impl Information {
     /// Return the number of links to this file.
     ///
     /// This corresponds to `nNumberOfLinks`.
-    pub fn number_of_links(&self) -> u64 {
-        self.0.nNumberOfLinks as u64
+    pub fn number_of_links(&self) -> u32 {
+        self.0.nNumberOfLinks
     }
 
     /// Return the index of this file. The index of a file is a purpotedly


### PR DESCRIPTION
Change the return types of `volume_serial_number()` and
`number_of_links()` from `u64` to `u32`. This makes it easier to migrate
code from manually using the underlying Windows APIs with `dwVolumeSerialNumber`
and `nNumberOfLinks`, which are `u32`, to using
`winapi_util::file::Information` instead.

This also aligns with Rust nightly's [`windows_by_handle`] feature,
where the [corresponding types are `u32`].

[`windows_by_handle`]: https://github.com/rust-lang/rust/issues/63010
[corresponding types are `u32`]: https://doc.rust-lang.org/stable/std/os/windows/fs/trait.MetadataExt.html#tymethod.volume_serial_number
