### PR TITLE
Add a convenient wrapper for calling `QueryPerformanceFrequency`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ features = [
   "fileapi",
   "minwindef",
   "processenv",
+  "profileapi",
   "winbase",
   "wincon",
   "winerror",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,6 @@ pub mod console;
 #[cfg(windows)]
 pub mod file;
 #[cfg(windows)]
+pub mod time;
+#[cfg(windows)]
 mod win;

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,17 @@
+use std::io;
+use std::mem;
+
+use winapi::um::{
+    profileapi::QueryPerformanceFrequency, winnt::LARGE_INTEGER,
+};
+
+pub fn perf_counter_frequency() -> io::Result<u64> {
+    unsafe {
+        let mut frequency: LARGE_INTEGER = mem::zeroed();
+        let rc = QueryPerformanceFrequency(&mut frequency);
+        if rc == 0 {
+            return Err(io::Error::last_os_error());
+        };
+        Ok(*frequency.QuadPart() as u64)
+    }
+}


### PR DESCRIPTION
This adds `perf_counter_frequency`, a convenient wrapper around win32's [`QueryPerformanceFrequency`](https://docs.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancefrequency).