### PR TITLE
Ensure stdio handles are never null when converting to `HandleRef`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ features = [
   "consoleapi",
   "errhandlingapi",
   "fileapi",
+  "handleapi",
   "minwindef",
   "processenv",
   "winbase",

--- a/src/win.rs
+++ b/src/win.rs
@@ -133,6 +133,15 @@ impl HandleRef {
     /// Create a borrowed handle to stdin.
     ///
     /// When the returned handle is dropped, stdin is not closed.
+    ///
+    /// If there is no stdin handle then `INVALID_HANDLE_VALUE` will be used
+    /// as the underlying file handle. This is likely to cause any use of the
+    /// handle to fail.
+    ///
+    /// The handle will most commonly be missing in GUI applications using the
+    /// ["windows" subsystem][subsystem].
+    ///
+    /// [subsystem]: https://doc.rust-lang.org/reference/runtime.html?#the-windows_subsystem-attribute
     pub fn stdin() -> HandleRef {
         unsafe { HandleRef::from_raw_handle(nonnull_handle(io::stdin())) }
     }
@@ -140,6 +149,15 @@ impl HandleRef {
     /// Create a handle to stdout.
     ///
     /// When the returned handle is dropped, stdout is not closed.
+    ///
+    /// If there is no stdout handle then `INVALID_HANDLE_VALUE` will be used
+    /// as the underlying file handle. This is likely to cause any use of the
+    /// handle to fail.
+    ///
+    /// The handle will most commonly be missing in GUI applications using the
+    /// ["windows" subsystem][subsystem].
+    ///
+    /// [subsystem]: https://doc.rust-lang.org/reference/runtime.html?#the-windows_subsystem-attribute
     pub fn stdout() -> HandleRef {
         unsafe { HandleRef::from_raw_handle(nonnull_handle(io::stdout())) }
     }
@@ -147,6 +165,15 @@ impl HandleRef {
     /// Create a handle to stderr.
     ///
     /// When the returned handle is dropped, stderr is not closed.
+    ///
+    /// If there is no stderr handle then `INVALID_HANDLE_VALUE` will be used
+    /// as the underlying file handle. This is likely to cause any use of the
+    /// handle to fail.
+    ///
+    /// The handle will most commonly be missing in GUI applications using the
+    /// ["windows" subsystem][subsystem].
+    ///
+    /// [subsystem]: https://doc.rust-lang.org/reference/runtime.html?#the-windows_subsystem-attribute
     pub fn stderr() -> HandleRef {
         unsafe { HandleRef::from_raw_handle(nonnull_handle(io::stderr())) }
     }


### PR DESCRIPTION
This fixes [this test case](https://github.com/rust-lang/rust/issues/88576#issue-985818273), which means `env_logger` will no longer panic on stable. I'm not totally happy with this change because it's a workaround rather than a real fix. But I think something like this is the best the can be done without changing the API or how people use it.