### PR TITLE
Port winapi_util from winapi to windows-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,30 +2,23 @@
 name = "winapi-util"
 version = "0.1.6"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
-description = "A dumping ground for high level safe wrappers over winapi."
+description = "A dumping ground for high level safe wrappers over windows-sys."
 documentation = "https://docs.rs/winapi-util"
 homepage = "https://github.com/BurntSushi/winapi-util"
 repository = "https://github.com/BurntSushi/winapi-util"
 readme = "README.md"
-keywords = ["windows", "winapi", "util", "win"]
+keywords = ["windows", "windows-sys", "util", "win"]
 license = "Unlicense/MIT"
 categories = ["os::windows-apis", "external-ffi-bindings"]
 edition = "2021"
 
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.52.0"
 features = [
-  "std",
-  "consoleapi",
-  "errhandlingapi",
-  "fileapi",
-  "minwindef",
-  "processenv",
-  "sysinfoapi",
-  "winbase",
-  "wincon",
-  "winerror",
-  "winnt",
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+  "Win32_System_Console",
+  "Win32_System_SystemInformation",
 ]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 winapi-util
 ===========
 This crate provides a smattering of safe wrappers around various parts of the
-[winapi](https://crates.io/crates/winapi) crate.
+[windows-sys](https://crates.io/crates/windows-sys) crate.
 
 [![Build status](https://github.com/BurntSushi/winapi-util/workflows/ci/badge.svg)](https://github.com/BurntSushi/winapi-util/actions)
 [![](http://meritbadge.herokuapp.com/winapi-util)](https://crates.io/crates/winapi-util)

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,24 +1,24 @@
 use std::{io, mem};
 
-use winapi::{
-    shared::minwindef::WORD,
-    um::{
-        consoleapi::{GetConsoleMode, SetConsoleMode},
-        wincon::{
-            self, GetConsoleScreenBufferInfo, SetConsoleTextAttribute,
-            CONSOLE_SCREEN_BUFFER_INFO, FOREGROUND_BLUE as FG_BLUE,
-            FOREGROUND_GREEN as FG_GREEN,
-            FOREGROUND_INTENSITY as FG_INTENSITY, FOREGROUND_RED as FG_RED,
-        },
-    },
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Console::{GetConsoleMode, SetConsoleMode};
+use windows_sys::Win32::System::Console::{
+    GetConsoleScreenBufferInfo, SetConsoleTextAttribute,
+    CONSOLE_SCREEN_BUFFER_INFO, ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+    FOREGROUND_BLUE, FOREGROUND_GREEN, FOREGROUND_INTENSITY, FOREGROUND_RED,
 };
 
 use crate::{AsHandleRef, HandleRef};
 
-const FG_CYAN: WORD = FG_BLUE | FG_GREEN;
-const FG_MAGENTA: WORD = FG_BLUE | FG_RED;
-const FG_YELLOW: WORD = FG_GREEN | FG_RED;
-const FG_WHITE: WORD = FG_BLUE | FG_GREEN | FG_RED;
+use FOREGROUND_BLUE as FG_BLUE;
+use FOREGROUND_GREEN as FG_GREEN;
+use FOREGROUND_INTENSITY as FG_INTENSITY;
+use FOREGROUND_RED as FG_RED;
+
+const FG_CYAN: u16 = FG_BLUE | FG_GREEN;
+const FG_MAGENTA: u16 = FG_BLUE | FG_RED;
+const FG_YELLOW: u16 = FG_GREEN | FG_RED;
+const FG_WHITE: u16 = FG_BLUE | FG_GREEN | FG_RED;
 
 /// Query the given handle for information about the console's screen buffer.
 ///
@@ -33,7 +33,7 @@ pub fn screen_buffer_info<H: AsHandleRef>(
 ) -> io::Result<ScreenBufferInfo> {
     unsafe {
         let mut info: CONSOLE_SCREEN_BUFFER_INFO = mem::zeroed();
-        let rc = GetConsoleScreenBufferInfo(h.as_raw(), &mut info);
+        let rc = GetConsoleScreenBufferInfo(h.as_raw() as HANDLE, &mut info);
         if rc == 0 {
             return Err(io::Error::last_os_error());
         }
@@ -50,7 +50,9 @@ pub fn set_text_attributes<H: AsHandleRef>(
     h: H,
     attributes: u16,
 ) -> io::Result<()> {
-    if unsafe { SetConsoleTextAttribute(h.as_raw(), attributes) } == 0 {
+    if unsafe { SetConsoleTextAttribute(h.as_raw() as HANDLE, attributes) }
+        == 0
+    {
         Err(io::Error::last_os_error())
     } else {
         Ok(())
@@ -65,7 +67,7 @@ pub fn set_text_attributes<H: AsHandleRef>(
 /// [`GetConsoleMode`]: https://docs.microsoft.com/en-us/windows/console/getconsolemode
 pub fn mode<H: AsHandleRef>(h: H) -> io::Result<u32> {
     let mut mode = 0;
-    if unsafe { GetConsoleMode(h.as_raw(), &mut mode) } == 0 {
+    if unsafe { GetConsoleMode(h.as_raw() as HANDLE, &mut mode) } == 0 {
         Err(io::Error::last_os_error())
     } else {
         Ok(mode)
@@ -79,7 +81,7 @@ pub fn mode<H: AsHandleRef>(h: H) -> io::Result<u32> {
 ///
 /// [`SetConsoleMode`]: https://docs.microsoft.com/en-us/windows/console/setconsolemode
 pub fn set_mode<H: AsHandleRef>(h: H, mode: u32) -> io::Result<()> {
-    if unsafe { SetConsoleMode(h.as_raw(), mode) } == 0 {
+    if unsafe { SetConsoleMode(h.as_raw() as HANDLE, mode) } == 0 {
         Err(io::Error::last_os_error())
     } else {
         Ok(())
@@ -280,7 +282,7 @@ impl Console {
         &mut self,
         yes: bool,
     ) -> io::Result<()> {
-        let vt = wincon::ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        let vt = ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
         let handle = self.kind.handle();
         let old_mode = mode(&handle)?;
@@ -302,7 +304,7 @@ struct TextAttributes {
 }
 
 impl TextAttributes {
-    fn to_word(&self) -> WORD {
+    fn to_word(&self) -> u16 {
         let mut w = 0;
         w |= self.fg_color.to_fg();
         w |= self.fg_intense.to_fg();
@@ -311,7 +313,7 @@ impl TextAttributes {
         w
     }
 
-    fn from_word(word: WORD) -> TextAttributes {
+    fn from_word(word: u16) -> TextAttributes {
         TextAttributes {
             fg_color: Color::from_fg(word),
             fg_intense: Intense::from_fg(word),
@@ -330,22 +332,22 @@ pub enum Intense {
 }
 
 impl Intense {
-    fn to_bg(&self) -> WORD {
+    fn to_bg(&self) -> u16 {
         self.to_fg() << 4
     }
 
-    fn from_bg(word: WORD) -> Intense {
+    fn from_bg(word: u16) -> Intense {
         Intense::from_fg(word >> 4)
     }
 
-    fn to_fg(&self) -> WORD {
+    fn to_fg(&self) -> u16 {
         match *self {
             Intense::No => 0,
             Intense::Yes => FG_INTENSITY,
         }
     }
 
-    fn from_fg(word: WORD) -> Intense {
+    fn from_fg(word: u16) -> Intense {
         if word & FG_INTENSITY > 0 {
             Intense::Yes
         } else {
@@ -369,15 +371,15 @@ pub enum Color {
 }
 
 impl Color {
-    fn to_bg(&self) -> WORD {
+    fn to_bg(&self) -> u16 {
         self.to_fg() << 4
     }
 
-    fn from_bg(word: WORD) -> Color {
+    fn from_bg(word: u16) -> Color {
         Color::from_fg(word >> 4)
     }
 
-    fn to_fg(&self) -> WORD {
+    fn to_fg(&self) -> u16 {
         match *self {
             Color::Black => 0,
             Color::Blue => FG_BLUE,
@@ -390,7 +392,7 @@ impl Color {
         }
     }
 
-    fn from_fg(word: WORD) -> Color {
+    fn from_fg(word: u16) -> Color {
         match word & 0b111 {
             FG_BLUE => Color::Blue,
             FG_GREEN => Color::Green,

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,15 +1,10 @@
 use std::{io, mem};
 
-use winapi::{
-    shared::{minwindef::FILETIME, winerror::NO_ERROR},
-    um::{
-        errhandlingapi::GetLastError,
-        fileapi::{
-            GetFileInformationByHandle, GetFileType,
-            BY_HANDLE_FILE_INFORMATION,
-        },
-        winnt,
-    },
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Foundation::{GetLastError, FILETIME, NO_ERROR};
+use windows_sys::Win32::Storage::FileSystem::{
+    GetFileInformationByHandle, GetFileType, BY_HANDLE_FILE_INFORMATION,
+    FILE_ATTRIBUTE_HIDDEN,
 };
 
 use crate::AsHandleRef;
@@ -25,7 +20,7 @@ use crate::AsHandleRef;
 pub fn information<H: AsHandleRef>(h: H) -> io::Result<Information> {
     unsafe {
         let mut info: BY_HANDLE_FILE_INFORMATION = mem::zeroed();
-        let rc = GetFileInformationByHandle(h.as_raw(), &mut info);
+        let rc = GetFileInformationByHandle(h.as_raw() as HANDLE, &mut info);
         if rc == 0 {
             return Err(io::Error::last_os_error());
         };
@@ -42,7 +37,7 @@ pub fn information<H: AsHandleRef>(h: H) -> io::Result<Information> {
 /// [`GetFileType`]: https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-getfiletype
 pub fn typ<H: AsHandleRef>(h: H) -> io::Result<Type> {
     unsafe {
-        let rc = GetFileType(h.as_raw());
+        let rc = GetFileType(h.as_raw() as HANDLE);
         if rc == 0 && GetLastError() != NO_ERROR {
             return Err(io::Error::last_os_error());
         }
@@ -53,7 +48,7 @@ pub fn typ<H: AsHandleRef>(h: H) -> io::Result<Type> {
 /// Returns true if and only if the given file attributes contain the
 /// `FILE_ATTRIBUTE_HIDDEN` attribute.
 pub fn is_hidden(file_attributes: u64) -> bool {
-    file_attributes & (winnt::FILE_ATTRIBUTE_HIDDEN as u64) > 0
+    file_attributes & (FILE_ATTRIBUTE_HIDDEN as u64) > 0
 }
 
 /// Represents file information such as creation time, file size, etc.
@@ -139,25 +134,25 @@ impl Type {
     /// Returns true if this type represents a character file, which is
     /// typically an LPT device or a console.
     pub fn is_char(&self) -> bool {
-        self.0 == ::winapi::um::winbase::FILE_TYPE_CHAR
+        self.0 == ::windows_sys::Win32::Storage::FileSystem::FILE_TYPE_CHAR
     }
 
     /// Returns true if this type represents a disk file.
     pub fn is_disk(&self) -> bool {
-        self.0 == ::winapi::um::winbase::FILE_TYPE_DISK
+        self.0 == ::windows_sys::Win32::Storage::FileSystem::FILE_TYPE_DISK
     }
 
     /// Returns true if this type represents a sock, named pipe or an
     /// anonymous pipe.
     pub fn is_pipe(&self) -> bool {
-        self.0 == ::winapi::um::winbase::FILE_TYPE_PIPE
+        self.0 == ::windows_sys::Win32::Storage::FileSystem::FILE_TYPE_PIPE
     }
 
     /// Returns true if this type is not known.
     ///
     /// Note that this never corresponds to a failure.
     pub fn is_unknown(&self) -> bool {
-        self.0 == ::winapi::um::winbase::FILE_TYPE_UNKNOWN
+        self.0 == ::windows_sys::Win32::Storage::FileSystem::FILE_TYPE_UNKNOWN
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 /*!
-This crate provides a smattering of safe routines for parts of winapi. The
+This crate provides a smattering of safe routines for parts of windows-sys. The
 primary purpose of this crate is to serve as a dumping ground for various
-utility functions that make interactions with winapi safe. This permits the
+utility functions that make interactions with windows-sys safe. This permits the
 centralization of `unsafe` when dealing with Windows APIs, and thus makes it
 easier to audit.
 

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -1,6 +1,8 @@
 use std::{ffi::OsString, io};
 
-use winapi::um::sysinfoapi::{GetComputerNameExW, COMPUTER_NAME_FORMAT};
+use windows_sys::Win32::System::SystemInformation::{
+    GetComputerNameExW, COMPUTER_NAME_FORMAT,
+};
 
 /// The type of name to be retrieved by [`get_computer_name`].
 #[derive(Clone, Copy, Debug)]
@@ -49,19 +51,25 @@ pub enum ComputerNameKind {
 impl ComputerNameKind {
     fn to_format(&self) -> COMPUTER_NAME_FORMAT {
         use self::ComputerNameKind::*;
-        use winapi::um::sysinfoapi;
+        use windows_sys::Win32::System::SystemInformation;
 
         match *self {
-            DnsDomain => sysinfoapi::ComputerNameDnsDomain,
-            DnsFullyQualified => sysinfoapi::ComputerNameDnsFullyQualified,
-            DnsHostname => sysinfoapi::ComputerNameDnsHostname,
-            NetBios => sysinfoapi::ComputerNameNetBIOS,
-            PhysicalDnsDomain => sysinfoapi::ComputerNamePhysicalDnsDomain,
-            PhysicalDnsFullyQualified => {
-                sysinfoapi::ComputerNamePhysicalDnsFullyQualified
+            DnsDomain => SystemInformation::ComputerNameDnsDomain,
+            DnsFullyQualified => {
+                SystemInformation::ComputerNameDnsFullyQualified
             }
-            PhysicalDnsHostname => sysinfoapi::ComputerNamePhysicalDnsHostname,
-            PhysicalNetBios => sysinfoapi::ComputerNamePhysicalNetBIOS,
+            DnsHostname => SystemInformation::ComputerNameDnsHostname,
+            NetBios => SystemInformation::ComputerNameNetBIOS,
+            PhysicalDnsDomain => {
+                SystemInformation::ComputerNamePhysicalDnsDomain
+            }
+            PhysicalDnsFullyQualified => {
+                SystemInformation::ComputerNamePhysicalDnsFullyQualified
+            }
+            PhysicalDnsHostname => {
+                SystemInformation::ComputerNamePhysicalDnsHostname
+            }
+            PhysicalNetBios => SystemInformation::ComputerNamePhysicalNetBIOS,
         }
     }
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -66,7 +66,7 @@ impl Handle {
     pub fn from_path_any<P: AsRef<Path>>(path: P) -> io::Result<Handle> {
         use std::fs::OpenOptions;
         use std::os::windows::fs::OpenOptionsExt;
-        use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+        use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
 
         let file = OpenOptions::new()
             .read(true)


### PR DESCRIPTION
This ports winapi_util from using winapi internally to using windows-sys
internally. 

The port is mostly straightforward, except that windows-sys declares
constants like `FOREGROUND_BLUE` with type `u32`, which is inconvenient
because they are passed to an API that uses `u16`, but the workaround
is simple and I've filed an issue in windows-sys.

Background: Some projects I'm working on which use winapi_util are
switching to windows-sys because it covers some APIs we need that
winapi lacks and winapi is not responsive on a PR to add them. I don't
know if others are interested in making this change; if not, feel free to
close this.