### PR TITLE
add safe API wrapper for `GetComputerNameExW`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         include:
         - build: pinned
           os: windows-latest
-          rust: 1.34.0
+          rust: 1.72.0
         - build: stable
           os: windows-latest
           rust: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,74 +1,85 @@
 name: ci
 on:
   pull_request:
+    branches:
+    - master
   push:
     branches:
     - master
   schedule:
   - cron: '00 01 * * *'
+
+# The section is needed to drop write-all permissions that are granted on
+# `schedule` event. By specifying any permission explicitly all others are set
+# to none. By using the principle of least privilege the damage a compromised
+# workflow can do (because of an injection or compromised third party tool or
+# action) is restricted. Currently the worklow doesn't need any additional
+# permission except for pulling the code. Adding labels to issues, commenting
+# on pull-requests, etc. may need additional permissions:
+#
+# Syntax for this section:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+#
+# Reference for how to assign permissions on a job-by-job basis:
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+#
+# Reference for available permissions that we can enable if needed:
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+permissions:
+  # to fetch code (actions/checkout)
+  contents: read
+
 jobs:
   test:
     name: test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        build:
-        - pinned
-        - stable
-        - beta
-        - nightly
-        - win-gnu
-        - linux
-        - macos
         include:
         - build: pinned
-          os: windows-2019
+          os: windows-latest
           rust: 1.34.0
         - build: stable
-          os: windows-2019
+          os: windows-latest
           rust: stable
         - build: beta
-          os: windows-2019
+          os: windows-latest
           rust: beta
         - build: nightly
-          os: ubuntu-18.04
+          os: windows-latest
           rust: nightly
         - build: win-gnu
-          os: windows-2019
+          os: windows-latest
           rust: stable-x86_64-gnu
         - build: linux
-          os: ubuntu-18.04
+          os: ubuntu-latest
           rust: stable
         - build: macos
           os: macos-latest
           rust: stable
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
+      uses: actions/checkout@v4
     - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        rust-version: ${{ matrix.rust }}
+        toolchain: ${{ matrix.rust }}
     - run: cargo build --verbose
     - run: cargo doc --verbose
     - run: cargo test --verbose
 
   rustfmt:
     name: rustfmt
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
+      uses: actions/checkout@v4
     - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        rust-version: stable
-    - name: Install rustfmt
-      run: rustup component add rustfmt
+        toolchain: stable
+        components: rustfmt
     - name: Check formatting
       run: |
         cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
     - run: cargo build --verbose
     - run: cargo doc --verbose
     - run: cargo test --verbose
+    - name: Show all computer names
+      run: cargo test --lib sysinfo::tests::itworks -- --nocapture
 
   rustfmt:
     name: rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ features = [
   "fileapi",
   "minwindef",
   "processenv",
+  "sysinfoapi",
   "winbase",
   "wincon",
   "winerror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["windows", "winapi", "util", "win"]
 license = "Unlicense/MIT"
 categories = ["os::windows-apis", "external-ffi-bindings"]
-edition = "2018"
+edition = "2021"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/README.md
+++ b/README.md
@@ -16,12 +16,7 @@ https://docs.rs/winapi-util
 
 ### Usage
 
-Add this to your `Cargo.toml`:
-
-```toml
-[dependencies]
-winapi-util = "0.1"
-```
+Run `cargo add winapi-util` to add this dependency to your `Cargo.toml` file.
 
 
 ### Notes
@@ -46,7 +41,7 @@ got things right is most appreciated.
 
 ### Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.34.0`.
+This crate's minimum supported `rustc` version is `1.72.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in non-breaking version updates. For example, if `crate 1.0`

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,13 +1,16 @@
-use std::io;
-use std::mem;
+use std::{io, mem};
 
-use winapi::shared::minwindef::WORD;
-use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
-use winapi::um::wincon::{
-    self, GetConsoleScreenBufferInfo, SetConsoleTextAttribute,
-    CONSOLE_SCREEN_BUFFER_INFO, FOREGROUND_BLUE as FG_BLUE,
-    FOREGROUND_GREEN as FG_GREEN, FOREGROUND_INTENSITY as FG_INTENSITY,
-    FOREGROUND_RED as FG_RED,
+use winapi::{
+    shared::minwindef::WORD,
+    um::{
+        consoleapi::{GetConsoleMode, SetConsoleMode},
+        wincon::{
+            self, GetConsoleScreenBufferInfo, SetConsoleTextAttribute,
+            CONSOLE_SCREEN_BUFFER_INFO, FOREGROUND_BLUE as FG_BLUE,
+            FOREGROUND_GREEN as FG_GREEN,
+            FOREGROUND_INTENSITY as FG_INTENSITY, FOREGROUND_RED as FG_RED,
+        },
+    },
 };
 
 use crate::{AsHandleRef, HandleRef};
@@ -208,7 +211,7 @@ impl Console {
         let h = kind.handle();
         let info = screen_buffer_info(&h)?;
         let attr = TextAttributes::from_word(info.attributes());
-        Ok(Console { kind: kind, start_attr: attr, cur_attr: attr })
+        Ok(Console { kind, start_attr: attr, cur_attr: attr })
     }
 
     /// Create a new Console to stdout.

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,13 +1,16 @@
-use std::io;
-use std::mem;
+use std::{io, mem};
 
-use winapi::shared::minwindef::FILETIME;
-use winapi::shared::winerror::NO_ERROR;
-use winapi::um::errhandlingapi::GetLastError;
-use winapi::um::fileapi::{
-    GetFileInformationByHandle, GetFileType, BY_HANDLE_FILE_INFORMATION,
+use winapi::{
+    shared::{minwindef::FILETIME, winerror::NO_ERROR},
+    um::{
+        errhandlingapi::GetLastError,
+        fileapi::{
+            GetFileInformationByHandle, GetFileType,
+            BY_HANDLE_FILE_INFORMATION,
+        },
+        winnt,
+    },
 };
-use winapi::um::winnt;
 
 use crate::AsHandleRef;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,7 @@ pub mod console;
 #[cfg(windows)]
 pub mod file;
 #[cfg(windows)]
+/// Safe routines for querying various Windows specific properties.
+pub mod sysinfo;
+#[cfg(windows)]
 mod win;

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -1,0 +1,153 @@
+use std::{ffi::OsString, io};
+
+use winapi::um::sysinfoapi::{GetComputerNameExW, COMPUTER_NAME_FORMAT};
+
+/// The type of name to be retrieved by [`get_computer_name`].
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum ComputerNameKind {
+    /// The name of the DNS domain assigned to the local computer. If the local
+    /// computer is a node in a cluster, lpBuffer receives the DNS domain name
+    /// of the cluster virtual server.
+    DnsDomain,
+    /// The fully qualified DNS name that uniquely identifies the local
+    /// computer. This name is a combination of the DNS host name and the DNS
+    /// domain name, using the form HostName.DomainName. If the local computer
+    /// is a node in a cluster, lpBuffer receives the fully qualified DNS name
+    /// of the cluster virtual server.
+    DnsFullyQualified,
+    /// The DNS host name of the local computer. If the local computer is a
+    /// node in a cluster, lpBuffer receives the DNS host name of the cluster
+    /// virtual server.
+    DnsHostname,
+    /// The NetBIOS name of the local computer. If the local computer is a node
+    /// in a cluster, lpBuffer receives the NetBIOS name of the cluster virtual
+    /// server.
+    NetBios,
+    /// The name of the DNS domain assigned to the local computer. If the local
+    /// computer is a node in a cluster, lpBuffer receives the DNS domain name
+    /// of the local computer, not the name of the cluster virtual server.
+    PhysicalDnsDomain,
+    /// The fully qualified DNS name that uniquely identifies the computer. If
+    /// the local computer is a node in a cluster, lpBuffer receives the fully
+    /// qualified DNS name of the local computer, not the name of the cluster
+    /// virtual server.
+    ///
+    /// The fully qualified DNS name is a combination of the DNS host name and
+    /// the DNS domain name, using the form HostName.DomainName.
+    PhysicalDnsFullyQualified,
+    /// The DNS host name of the local computer. If the local computer is a
+    /// node in a cluster, lpBuffer receives the DNS host name of the local
+    /// computer, not the name of the cluster virtual server.
+    PhysicalDnsHostname,
+    /// The NetBIOS name of the local computer. If the local computer is a node
+    /// in a cluster, lpBuffer receives the NetBIOS name of the local computer,
+    /// not the name of the cluster virtual server.
+    PhysicalNetBios,
+}
+
+impl ComputerNameKind {
+    fn to_format(&self) -> COMPUTER_NAME_FORMAT {
+        use self::ComputerNameKind::*;
+        use winapi::um::sysinfoapi;
+
+        match *self {
+            DnsDomain => sysinfoapi::ComputerNameDnsDomain,
+            DnsFullyQualified => sysinfoapi::ComputerNameDnsFullyQualified,
+            DnsHostname => sysinfoapi::ComputerNameDnsHostname,
+            NetBios => sysinfoapi::ComputerNameNetBIOS,
+            PhysicalDnsDomain => sysinfoapi::ComputerNamePhysicalDnsDomain,
+            PhysicalDnsFullyQualified => {
+                sysinfoapi::ComputerNamePhysicalDnsFullyQualified
+            }
+            PhysicalDnsHostname => sysinfoapi::ComputerNamePhysicalDnsHostname,
+            PhysicalNetBios => sysinfoapi::ComputerNamePhysicalNetBIOS,
+        }
+    }
+}
+/// Retrieves a NetBIOS or DNS name associated with the local computer.
+///
+/// The names are established at system startup, when the system reads them
+/// from the registry.
+///
+/// This corresponds to calling [`GetComputerNameExW`].
+///
+/// [`GetComputerNameExW`]: https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getcomputernameexw
+pub fn get_computer_name(kind: ComputerNameKind) -> io::Result<OsString> {
+    use std::os::windows::ffi::OsStringExt;
+
+    let format = kind.to_format();
+    let mut len1 = 0;
+    // SAFETY: As documented, we call this with a null pointer which will in
+    // turn cause this routine to write the required buffer size fo `len1`.
+    // Also, we explicitly ignore the return value since we expect this call to
+    // fail given that the destination buffer is too small by design.
+    let _ =
+        unsafe { GetComputerNameExW(format, std::ptr::null_mut(), &mut len1) };
+
+    let len = match usize::try_from(len1) {
+        Ok(len) => len,
+        Err(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "GetComputerNameExW buffer length overflowed usize",
+            ))
+        }
+    };
+    let mut buf = vec![0; len];
+    let mut len2 = len1;
+    // SAFETY: We pass a valid pointer to an appropriately sized Vec<u16>.
+    let rc =
+        unsafe { GetComputerNameExW(format, buf.as_mut_ptr(), &mut len2) };
+    if rc == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // Apparently, the subsequent call writes the number of characters written
+    // to the buffer to `len2` but not including the NUL terminator. Notice
+    // that in the first call above, the length written to `len1` *does*
+    // include the NUL terminator. Therefore, we expect `len1` to be at least
+    // one greater than `len2`. If not, then something weird has happened and
+    // we report an error.
+    if len1 <= len2 {
+        let msg = format!(
+            "GetComputerNameExW buffer length mismatch, \
+             expected length strictly less than {} \
+             but got {}",
+            len1, len2,
+        );
+        return Err(io::Error::new(io::ErrorKind::Other, msg));
+    }
+    let len = usize::try_from(len2).expect("len1 fits implies len2 fits");
+    Ok(OsString::from_wide(&buf[..len]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // This test doesn't really check anything other than that we can
+    // successfully query all kinds of computer names. We just print them out
+    // since there aren't really any properties about the names that we can
+    // assert.
+    //
+    // We specifically run this test in CI with --nocapture so that we can see
+    // the output.
+    #[test]
+    fn itworks() {
+        let kinds = [
+            ComputerNameKind::DnsDomain,
+            ComputerNameKind::DnsFullyQualified,
+            ComputerNameKind::DnsHostname,
+            ComputerNameKind::NetBios,
+            ComputerNameKind::PhysicalDnsDomain,
+            ComputerNameKind::PhysicalDnsFullyQualified,
+            ComputerNameKind::PhysicalDnsHostname,
+            ComputerNameKind::PhysicalNetBios,
+        ];
+        for kind in kinds {
+            let result = get_computer_name(kind);
+            let name = result.unwrap();
+            println!("{kind:?}: {name:?}");
+        }
+    }
+}

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,10 +1,10 @@
-use std::fs::File;
-use std::io;
-use std::os::windows::io::{
-    AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle,
+use std::{
+    fs::File,
+    io,
+    os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
+    path::Path,
+    process,
 };
-use std::path::Path;
-use std::process;
 
 /// A handle represents an owned and valid Windows handle to a file-like
 /// object.


### PR DESCRIPTION
This is meant to help ripgrep get the hostname of the current machine automatically on Windows.