### PR TITLE
Update windows-sys to version 0.59.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["os::windows-apis", "external-ffi-bindings"]
 edition = "2021"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.52.0"
+version = ">=0.48.0, <=0.59.*"
 features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",


### PR DESCRIPTION
Changes in this release include making the `HANDLE` type match rust's std type (i.e. `*mut c_void` instead of `isize`).

If it's ok with you, I've used a range dependency so that it is less likely that multiple versions of `windows-sys` appear in someone's dependency tree. According to the [stats](https://lib.rs/crates/windows-sys/rev), the last 3 versions (0.48.0. 0.52.0 and 0.59.0) account for most uses of `windows-sys`. I have tested that these versions work.

This shouldn't need to be updated often. The last release (0.52.0) was 9 months ago.