### PR TITLE
Support windows-sys v0.60.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["os::windows-apis", "external-ffi-bindings"]
 edition = "2021"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = ">=0.48.0, <=0.59.*"
+version = ">=0.48.0, <=0.60.*"
 features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",


### PR DESCRIPTION
Following the same pattern as #19.

I'm not sure if you want tests that do `cargo update --precise` for all of the various semver incompatible versions in this range

NOTE: I didn't run tests, I just made this change from the GitHub web UI; sorry about that. It looks like this repo has CI but maybe it didn't run on this PR.